### PR TITLE
Fix reference before assignment with no tests.

### DIFF
--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -470,12 +470,12 @@ class _XMLTestResult(_TextTestResult):
             testsuite = _XMLTestResult._report_testsuite(
                 suite_name, tests, doc, parentElement, self.properties
             )
-            xml_content = doc.toprettyxml(
-                indent='\t',
-                encoding=test_runner.encoding
-            )
 
             if outputHandledAsString:
+                xml_content = doc.toprettyxml(
+                    indent='\t',
+                    encoding=test_runner.encoding
+                )
                 filename = path.join(
                     test_runner.output,
                     'TEST-%s.xml' % suite_name)
@@ -483,6 +483,10 @@ class _XMLTestResult(_TextTestResult):
                     report_file.write(xml_content)
 
         if not outputHandledAsString:
+            xml_content = doc.toprettyxml(
+                indent='\t',
+                encoding=test_runner.encoding
+            )
             # Assume that test_runner.output is a stream
             test_runner.output.write(xml_content)
 


### PR DESCRIPTION
Fix "local variable 'xml_content' referenced before assignment" without any test suites/cases, and only export the XML once for the stream case.
